### PR TITLE
Build script fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /Makefile
 /uninstaller.sh
 /mysecureshell
+/utils/sftp-admin
+/utils/sftp-state
+/utils/sftp-who

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 #  - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install llvm35 && brew link --force llvm35; fi
 
 before_script:
-  - ./configure
+  - ./configure --prefix=/usr
 
 script:
   - sudo make install
@@ -60,6 +60,6 @@ addons:
       name: mysecureshell/mysecureshell
       description: MySecureShell
     notification_email: $COVERITY_SCAN_EMAIL
-    build_command_prepend: ./configure
+    build_command_prepend: ./configure --prefix=/usr
     build_command: make all
     branch_pattern: master

--- a/configure
+++ b/configure
@@ -677,6 +677,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -755,6 +756,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1007,6 +1009,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1144,7 +1155,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1297,6 +1308,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -6325,9 +6337,9 @@ fi
 
 
 #Own defines
-test "$prefix" = "NONE" && prefix=
-test "$exec_prefix" = "NONE" && exec_prefix=/usr
-test -z "$bindir" && bindir="/usr/bin"
+test "$prefix" = "NONE" && prefix=/usr/local
+test "$exec_prefix" = "NONE" && exec_prefix=$prefix
+sysconfdir=/etc
 test -z "$MSS_LOG" && MSS_LOG="/var/log/sftp-server.log"
 test -z "$MSS_CONF" && MSS_CONF="/etc/ssh/sftp_config"
 test -z "$MSS_SHUT" && MSS_SHUT="/etc/sftp.shut"

--- a/configure.in
+++ b/configure.in
@@ -143,9 +143,9 @@ AC_CHECK_LIB(acl, acl_get_entry, [])
 AC_CHECK_LIB(gnutls, gnutls_hash_init, [])
 
 #Own defines
-test "$prefix" = "NONE" && prefix=
-test "$exec_prefix" = "NONE" && exec_prefix=/usr
-test -z "$bindir" && bindir="/usr/bin"
+test "$prefix" = "NONE" && prefix=/usr/local
+test "$exec_prefix" = "NONE" && exec_prefix=$prefix
+sysconfdir=/etc
 test -z "$MSS_LOG" && MSS_LOG="/var/log/sftp-server.log"
 test -z "$MSS_CONF" && MSS_CONF="/etc/ssh/sftp_config"
 test -z "$MSS_SHUT" && MSS_SHUT="/etc/sftp.shut"

--- a/install.sh.in
+++ b/install.sh.in
@@ -105,7 +105,7 @@ filefound() {
 }
 
 shellfunc() {
-grepshell=`grep /usr/bin/mysecureshell $ETCDIR/shells`
+grepshell=`grep $BINDIR/mysecureshell $ETCDIR/shells`
 if [ "$?" = "0" ] ; then
 	echo "`MyGetLocale 'shellalreadyvd'`		`MyGetLocale 'ok'`"
 else
@@ -118,7 +118,7 @@ else
 	fi
 	case "$rep3" in
 		[yY])
-			echo "/usr/bin/mysecureshell" >> $ETCDIR/shells
+			echo "$BINDIR/mysecureshell" >> $ETCDIR/shells
 			echo `MyGetLocale 'shellvalid'`"		"`MyGetLocale 'ok'`
 			;;
 		*)

--- a/uninstaller.sh.in
+++ b/uninstaller.sh.in
@@ -64,7 +64,7 @@ test -z "$ans" && ans="n"
 case "$ans" in
 	[yY])
 		rm -f $BINDIR/MySecureShell $BINDIR/sftp-who $BINDIR/sftp-state $BINDIR/sftp-kill $BINDIR/sftp-admin $BINDIR/sftp-user
-		cat /etc/shells | grep -v MySecureShell > /tmp/shells~
+		cat /etc/shells | grep -vi mysecureshell > /tmp/shells~
 		mv /tmp/shells~ /etc/shells
 
 	# Only for Mac OS X


### PR DESCRIPTION
This PR contains several fixes to the build scripts.

- `install.sh.in`: The value of `$BINDIR` was ignored when writing to `/etc/shells`.

- `uninstaller.sh.in`: Use `grep -i` to ignore case when removing from `/etc/shells`.

- `configure.in`: Problems before this PR:

  1. By default binaries were installed to `/usr/bin` not `/usr/local/bin`, where the documentation (`--help`) says.

  2. Man pages would be installed to `/share`. That' because under the hood, only `exec_prefix=/usr` was set, but not `prefix`.

  3. The script appears to accept `--sysconfdir`, but many paths are hard-coded, e.g. `/etc/ssh/sftp_config`, not `${SYSCONFDIR}/ssh/sftp_config`.

  The current tweaks solve 1&2, by setting `prefix=/usr/local` by default.

  As for 3, this PR causes `--sysconfdir` to be completely ignored, and `/etc` to be used instead. The bigger problem is that I don't know how to make `SYSCONFDIR` default `/etc` rather than `${PREFIX}/etc`- this default is internal to one of the `autoconf` macros. But since many paths are hardcoded already, it must not hurt to plainly ignore that option.

  The alternative is not to ignore `SYSCONFDIR`, but then that would default to `${PREFIX}/etc`, so the explicit setting `./configure ... --sysconfdir=/etc` would be necessary to properly configure the package.