### PR TITLE
Rootless chrooted sftp

### DIFF
--- a/Core/conf.c
+++ b/Core/conf.c
@@ -121,6 +121,8 @@ static const tConf confParams[] =
 	{ "{last item}", CONF_IS_EMPTY, CONF_NOT_SHOW }
 };
 
+static const char * custom_config_file;
+
 void load_config(int verbose)
 {
 	if (init_user_info() == 0)
@@ -132,8 +134,9 @@ void load_config(int verbose)
 	hash_set("SERVER_IP", get_ip_server());
 	hash_set_int("CanChangeRights", 1);
 	hash_set_int("CanChangeTime", 1);
-	if (load_config_file(CONFIG_FILE, verbose, 10) == 0)
-		if (load_config_file(CONFIG_FILE2, verbose, 10) == 0)
+        if ((custom_config_file == 0 || load_config_file(custom_config_file, verbose, 10) == 0)
+            && load_config_file(CONFIG_FILE, verbose, 10) == 0
+            && load_config_file(CONFIG_FILE2, verbose, 10) == 0)
 		{
 			(void) fprintf(stderr,
 					"[ERROR]No valid config file were found. Please correct this.\n");
@@ -376,4 +379,9 @@ void processLine(char **tb, int max_recursive_left, int verbose)
 		if (notRecognized == 1)
 			(void) fprintf(stderr, "Property '%s' is not recognized !\n", tb[0]);
 	}
+}
+
+void set_custom_config_file(const char *config_file)
+{
+    custom_config_file = config_file;
 }

--- a/Core/conf.c
+++ b/Core/conf.c
@@ -121,7 +121,7 @@ static const tConf confParams[] =
 	{ "{last item}", CONF_IS_EMPTY, CONF_NOT_SHOW }
 };
 
-static const char * custom_config_file;
+static const char *_custom_config_file = NULL;
 
 void load_config(int verbose)
 {
@@ -134,7 +134,7 @@ void load_config(int verbose)
 	hash_set("SERVER_IP", get_ip_server());
 	hash_set_int("CanChangeRights", 1);
 	hash_set_int("CanChangeTime", 1);
-	if ((custom_config_file == 0 || load_config_file(custom_config_file, verbose, 10) == 0)
+	if ((_custom_config_file == NULL || load_config_file(_custom_config_file, verbose, 10) == 0)
 		&& load_config_file(CONFIG_FILE, verbose, 10) == 0
 		&& load_config_file(CONFIG_FILE2, verbose, 10) == 0)
 	{
@@ -383,5 +383,5 @@ void processLine(char **tb, int max_recursive_left, int verbose)
 
 void set_custom_config_file(const char *config_file)
 {
-	custom_config_file = config_file;
+	_custom_config_file = config_file;
 }

--- a/Core/conf.c
+++ b/Core/conf.c
@@ -134,14 +134,14 @@ void load_config(int verbose)
 	hash_set("SERVER_IP", get_ip_server());
 	hash_set_int("CanChangeRights", 1);
 	hash_set_int("CanChangeTime", 1);
-        if ((custom_config_file == 0 || load_config_file(custom_config_file, verbose, 10) == 0)
-            && load_config_file(CONFIG_FILE, verbose, 10) == 0
-            && load_config_file(CONFIG_FILE2, verbose, 10) == 0)
-		{
-			(void) fprintf(stderr,
-					"[ERROR]No valid config file were found. Please correct this.\n");
-			exit(2);
-		}
+	if ((custom_config_file == 0 || load_config_file(custom_config_file, verbose, 10) == 0)
+		&& load_config_file(CONFIG_FILE, verbose, 10) == 0
+		&& load_config_file(CONFIG_FILE2, verbose, 10) == 0)
+	{
+		(void) fprintf(stderr,
+				"[ERROR]No valid config file were found. Please correct this.\n");
+		exit(2);
+	}
 	free_user_info();
 	if (verbose > 0)
 	{
@@ -383,5 +383,5 @@ void processLine(char **tb, int max_recursive_left, int verbose)
 
 void set_custom_config_file(const char *config_file)
 {
-    custom_config_file = config_file;
+	custom_config_file = config_file;
 }

--- a/Core/conf.h
+++ b/Core/conf.h
@@ -26,3 +26,4 @@ int	load_config_file(const char *file, int verbose, int max_recursive_left);
 void	processLine(char **tb, int max_recursive_left, int verbose);
 /*@null@*/ char	*convert_str_with_resolv_env_to_str(const char *str);
 char	*convert_to_path(char *path);
+void	set_custom_config_file(const char *config_file);

--- a/Core/main.c
+++ b/Core/main.c
@@ -38,7 +38,8 @@
 static void reset_uid()
 {
 	//if we are in utset byte mode then we restore user's rights to avoid security problems
-	if (getuid() == geteuid()) return;
+	if (getuid() == geteuid())
+		return;
 	if (seteuid(getuid()) == -1 || setegid(getgid()) == -1)
 	{
 		perror("revoke root rights");

--- a/Core/main.c
+++ b/Core/main.c
@@ -140,15 +140,15 @@ int main(int ac, char **av, char **env)
 	if (ac == 3 && av[1] != NULL && av[2] != NULL && strcmp("-c", av[1]) == 0
 			&& (strstr(av[2], "sftp-server") != NULL || strstr(av[2], "MySecureShell") != NULL))
 		is_sftp = 1;
-        else if (ac == 5
+	else if (ac == 5
 			&& av[1] != NULL && av[2] != NULL && strcmp("--config", av[1]) == 0
 			&& av[3] != NULL && av[4] != NULL && strcmp("-c", av[3]) == 0
 			&& (strstr(av[4], "sftp-server") != NULL || strstr(av[4], "MySecureShell") != NULL))
-        {
+	{
 		reset_uid();
 		set_custom_config_file(av[2]);
 		is_sftp = 1;
-        }
+	}
 	else if (ac >= 3 && av[1] != NULL && av[2] != NULL && strcmp("-c", av[1]) == 0)
 		is_command = 1;
 	else

--- a/Core/main.c
+++ b/Core/main.c
@@ -35,6 +35,17 @@
 #include "../SftpServer/Log.h"
 #include "security.h"
 
+static void reset_uid()
+{
+	//if we are in utset byte mode then we restore user's rights to avoid security problems
+	if (getuid() == geteuid()) return;
+	if (seteuid(getuid()) == -1 || setegid(getgid()) == -1)
+	{
+		perror("revoke root rights");
+		exit(1);
+	}
+}
+
 static void showVersion(int showAll)
 {
 	(void) printf(
@@ -129,6 +140,15 @@ int main(int ac, char **av, char **env)
 	if (ac == 3 && av[1] != NULL && av[2] != NULL && strcmp("-c", av[1]) == 0
 			&& (strstr(av[2], "sftp-server") != NULL || strstr(av[2], "MySecureShell") != NULL))
 		is_sftp = 1;
+        else if (ac == 5
+			&& av[1] != NULL && av[2] != NULL && strcmp("--config", av[1]) == 0
+			&& av[3] != NULL && av[4] != NULL && strcmp("-c", av[3]) == 0
+			&& (strstr(av[4], "sftp-server") != NULL || strstr(av[4], "MySecureShell") != NULL))
+        {
+		reset_uid();
+		set_custom_config_file(av[2]);
+		is_sftp = 1;
+        }
 	else if (ac >= 3 && av[1] != NULL && av[2] != NULL && strcmp("-c", av[1]) == 0)
 		is_command = 1;
 	else
@@ -376,15 +396,7 @@ int main(int ac, char **av, char **env)
 	{
 		char *ptr;
 
-		if (getuid() != geteuid())
-		//if we are in utset byte mode then we restore user's rights to avoid security problems
-		{
-			if (seteuid(getuid()) == -1 || setegid(getgid()) == -1)
-			{
-				perror("revoke root rights");
-				exit(1);
-			}
-		}
+		reset_uid();
 		ptr = hash_get("Shell");
 		if (ptr != NULL)
 		{


### PR DESCRIPTION
This PR enables the use of a custom config file, for sftp mode only. The command line parameters must be exactly:

    mysecureshell --config /path/to/custom/config -c sftp-server

Details:

- When a custom config file is specified in sftp mode, `mysecureshell` will drop the setuid permission, if that one is set.

- The current option parsing is rather adhoc, so in the interest of not changing the code too much, only the exact syntax above will work.

- To enable root-less chrooted sftp with `mysecureshell`:

  - Build `mysecureshell`, install it in a private folder, e.g. `/path/to/mysecureshell`. Or else, convince the sysadmin to install it, if you can.

  - Create a custom config file `/path/to/custom-chroot.conf` of the form containing (among other things):

        <Default>
        StayAtHome              true    #limit client to his home
        VirtualChroot           true    #fake a chroot to the home account
        Home                    /path/to/custom-chroot
        </Default>

  - Create a custom ssh key to be used with this chroot only.

  - Add this to `authorized_keys`:

        command="/path/to/mysecureshell --config /path/to/custom-chroot.conf -c sftp-server",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding ssh-rsa ..."

Disclaimer: Use these instructions at your own risk.