### PR TITLE
Fixed Vagrantfile

### DIFF
--- a/deployment-tools/vagrant/Vagrantfile
+++ b/deployment-tools/vagrant/Vagrantfile
@@ -3,7 +3,7 @@
 # MySecureShell Team <https://github.com/mysecureshell/mysecureshell>
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = "2" 
+VAGRANTFILE_API_VERSION = "2"
 
 $install_mss = <<INSTALL
 echo "deb http://mysecureshell.free.fr/repository/index.php/debian/7.1 testing main
@@ -14,8 +14,8 @@ gpg --export E328F22B | apt-key add -
 apt-get update
 apt-get -y install mysecureshell
 pass=$(mkpasswd -m sha-512 -s mssuser)
-useradd -m -s /usr/bin/mysecureshell -p $pass mssuser
-chmod 4755 /usr/bin/mysecureshell
+useradd -m -s /bin/MySecureShell -p $pass mssuser
+chmod 4755 /bin/MySecureShell
 INSTALL
 
 $install_mss_dev = <<INSTALL


### PR DESCRIPTION
Vagrantfile seems to be outdated. The mysecureshell pkg that is installed on the image is installing the binaries under /bin instead of /usr/bin and the my secure shell binary is named MySecureShell instead of mysecureshell.

Fixed correspondingly the binary's path in useradd and chmod commands in Vagrantfile.