### PR TITLE
Fix missing include sys/types.h

### DIFF
--- a/SftpServer/Encode.c
+++ b/SftpServer/Encode.c
@@ -20,6 +20,7 @@
 #include "../config.h"
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/types.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdlib.h>

--- a/SftpServer/Handle.c
+++ b/SftpServer/Handle.c
@@ -18,6 +18,7 @@
  */
 
 #include "../config.h"
+#include <sys/types.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/SftpState/Main.c
+++ b/SftpState/Main.c
@@ -18,6 +18,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "../config.h"
+#include <sys/types.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/SftpWho/Main.c
+++ b/SftpWho/Main.c
@@ -19,6 +19,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "../config.h"
+#include <sys/types.h>
 #include <stdio.h>
 #include <time.h>
 #include <stdlib.h>


### PR DESCRIPTION
Without this patch compilation on musl libc fails with:

    unknown type name 'u_int32_t'
    unknown type name 'u_int64_t'

Taken from Alpine Linux, used `git am -3` to preserve credits to actual writer of this patch