### PR TITLE
Fix symlink calls

### DIFF
--- a/SftpServer/FileSystem.c
+++ b/SftpServer/FileSystem.c
@@ -548,9 +548,9 @@ static int FSLink(const int is_symlink, const char *target, const char *linkPath
 	else
 		returnValue = link(oldPath->realPath, newPath->realPath);
 	if (returnValue == 0)
-		returnValue = errnoToPortable(errno);
-	else
 		returnValue = SSH2_FX_OK;
+	else
+		returnValue = errnoToPortable(errno);
 	FSDestroyPath(oldPath);
 	FSDestroyPath(newPath);
 	return returnValue;

--- a/SftpServer/Sftp.c
+++ b/SftpServer/Sftp.c
@@ -800,8 +800,8 @@ void DoSymLink()
 	int status = SSH2_FX_OK;
 
 	id = BufferGetInt32(bIn);
-	link = convertFromUtf8(BufferGetString(bIn), 1);
 	target = convertFromUtf8(BufferGetString(bIn), 1);
+	link = convertFromUtf8(BufferGetString(bIn), 1);
 	if (HAS_BIT(gl_var->flagsDisable, SFTP_DISABLE_SYMLINK))
 	{
 		DEBUG((MYLOG_DEBUG, "[DoSymLink]Disabled by conf."));

--- a/SftpServer/SftpExt.c
+++ b/SftpServer/SftpExt.c
@@ -303,8 +303,8 @@ void DoExtHardLink(tBuffer *bIn, tBuffer *bOut, u_int32_t id)
 	char *link, *target;
 	int status = SSH2_FX_OK;
 
-	link = convertFromUtf8(BufferGetString(bIn), 1);
 	target = convertFromUtf8(BufferGetString(bIn), 1);
+	link = convertFromUtf8(BufferGetString(bIn), 1);
 	if (HAS_BIT(gl_var->flagsDisable, SFTP_DISABLE_SYMLINK))
 	{
 		DEBUG((MYLOG_DEBUG, "[DoExtHardLink]Disabled by conf."));


### PR DESCRIPTION
This PR adds a fix for issue https://github.com/mysecureshell/mysecureshell/issues/13 (simply switches the order of evaluation for `link` and `target` on `DoSymLink` and `DoExtHardLink`).

While testing the fix I also noticed the return code of the `FSLink` function was also switched (it returned an error when the calls to `symlink` or `link` returned `0`).