### PR TITLE
Fix POSIX ACL mask reset after chmod and file creation

### DIFF
--- a/SftpServer/FileSystem.c
+++ b/SftpServer/FileSystem.c
@@ -342,6 +342,8 @@ int FSOpenFile(const char *file, int *fileHandle, int flags, mode_t mode, struct
 		returnValue = errnoToPortable(errno);
 	else
 	{
+		if (HAS_BIT(flags, O_CREAT))
+			FSRecalcAclMask(path->realPath);
 		returnValue = SSH2_FX_OK;
 		if (st != NULL)
 			if (stat(path->realPath, st) == -1)

--- a/SftpServer/FileSystemAcl.c
+++ b/SftpServer/FileSystemAcl.c
@@ -124,6 +124,17 @@ int FSEnumAcl(const char *file, int resolvePath, void (*callback)(void *data, in
 	return SSH2_FX_OK;
 }
 
+void FSRecalcAclMask(const char *path)
+{
+	acl_t acl = acl_get_file(path, ACL_TYPE_ACCESS);
+	if (acl != NULL)
+	{
+		if (acl_calc_mask(&acl) == 0)
+			(void )acl_set_file(path, ACL_TYPE_ACCESS, acl);
+		(void )acl_free(acl);
+	}
+}
+
 #else //ifdef HAVE_CYGWIN
 
 int FSEnumAcl(const char *file, int resolvePath, void (*callback)(void *data, int type, u_int32_t id, u_int32_t mode), void *data, u_int32_t *nbEntries)
@@ -172,6 +183,12 @@ int FSEnumAcl(const char *file, int resolvePath, void (*callback)(void *data, in
 	return SSH2_FX_OK;
 }
 
+
+void FSRecalcAclMask(const char *path)
+{
+	/* Cygwin ACL API does not support acl_calc_mask */
+	(void )path;
+}
 
 #endif //HAVE_CYGWIN
 

--- a/SftpServer/FileSystemAcl.h
+++ b/SftpServer/FileSystemAcl.h
@@ -31,10 +31,12 @@
 #if(MSS_ACL)
 
 int FSEnumAcl(const char *file, int resolvePath, void (*callback)(void *data, int type, u_int32_t id, u_int32_t mode), void *data, u_int32_t *nbEntries);
+void FSRecalcAclMask(const char *path);
 
 #else
 
 #define FSEnumAcl(_A, _B, _C, _D, _E)	SSH2_FX_OK
+#define FSRecalcAclMask(_A)
 
 #endif //MSS_ACL
 

--- a/SftpServer/Sftp.c
+++ b/SftpServer/Sftp.c
@@ -661,6 +661,8 @@ void DoSetStat(int usePath)
 			}
 			if (chmod(resolvedPath->realPath, a->perm) == -1)
 				status = errnoToPortable(errno);
+			else
+				FSRecalcAclMask(resolvedPath->realPath);
 		}
 		if (HAS_BIT(a->flags, SSH2_FILEXFER_ATTR_ACMODTIME)
 				&& HAS_BIT(gl_var->flagsGlobals, SFTPWHO_CAN_CHG_TIME))

--- a/tests/docker-acl-test/Dockerfile
+++ b/tests/docker-acl-test/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bookworm
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        gcc make libacl1-dev acl openssh-server sshpass && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . /src/mysecureshell
+WORKDIR /src/mysecureshell
+
+RUN ./configure --prefix=/usr && make all && make install && \
+    chmod 4755 /usr/bin/mysecureshell
+
+# Create test users
+RUN addgroup --gid 3010 aclgroup && \
+    adduser --home /home/testuser --shell /usr/bin/mysecureshell \
+        --uid 4010 --gid 3010 --disabled-password --gecos "" testuser && \
+    echo 'testuser:testpass' | chpasswd && \
+    adduser --home /home/acluser --shell /bin/bash \
+        --uid 4011 --gid 3010 --disabled-password --gecos "" acluser && \
+    echo 'acluser:aclpass' | chpasswd
+
+# Configure sshd for password auth
+RUN mkdir -p /var/run/sshd && \
+    sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
+    sed -i 's/^#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config && \
+    ssh-keygen -A
+
+# Minimal sftp_config
+RUN printf '<Default>\n    LogLevel 5\n</Default>\n' > /etc/ssh/sftp_config
+
+COPY tests/docker-acl-test/run-test.sh /run-test.sh
+RUN chmod +x /run-test.sh
+
+CMD ["/run-test.sh"]

--- a/tests/docker-acl-test/README.md
+++ b/tests/docker-acl-test/README.md
@@ -1,0 +1,19 @@
+# ACL Mask Preservation Test
+
+Tests that POSIX ACL masks are preserved when files are uploaded via SFTP through MySecureShell (see [#69](https://github.com/mysecureshell/mysecureshell/issues/69)).
+
+## Usage
+
+From the repository root:
+
+```bash
+docker build -f tests/docker-acl-test/Dockerfile -t mss-acl-test .
+docker run --rm mss-acl-test
+```
+
+## What it tests
+
+1. Creates a directory with default ACLs granting a secondary user `rwx`
+2. Uploads a file via SFTP through MySecureShell
+3. Verifies the uploaded file's ACL entry retains write permission
+4. Verifies the ACL mask includes write permission (no `#effective:r-x` degradation)

--- a/tests/docker-acl-test/run-test.sh
+++ b/tests/docker-acl-test/run-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+echo "=== ACL Mask Preservation Test ==="
+
+# Start sshd
+/usr/sbin/sshd
+
+# Set up test directory with default ACLs
+TEST_DIR="/home/testuser/acltest"
+mkdir -p "$TEST_DIR"
+chown testuser:aclgroup "$TEST_DIR"
+chmod 0755 "$TEST_DIR"
+
+# Grant acluser rwx via default ACL so new files inherit it
+setfacl -d -m u:acluser:rwx "$TEST_DIR"
+setfacl -m u:acluser:rwx "$TEST_DIR"
+
+echo "--- Directory ACL before upload ---"
+getfacl "$TEST_DIR"
+
+# Create a local file to upload
+UPLOAD_FILE="/tmp/testfile.txt"
+echo "Hello ACL test" > "$UPLOAD_FILE"
+
+# Upload file via SFTP through MySecureShell
+echo "--- Uploading file via SFTP ---"
+sshpass -p 'testpass' sftp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    testuser@localhost <<SFTP_EOF
+cd acltest
+put $UPLOAD_FILE uploaded.txt
+SFTP_EOF
+
+UPLOADED="$TEST_DIR/uploaded.txt"
+
+if [ ! -f "$UPLOADED" ]; then
+    echo "FAIL: File was not uploaded"
+    exit 1
+fi
+
+echo "--- Uploaded file ACL ---"
+getfacl "$UPLOADED"
+
+# Check that acluser's ACL entry still has write permission
+# getfacl output for named user looks like: user:acluser:rwx
+ACL_LINE=$(getfacl "$UPLOADED" 2>/dev/null | grep "^user:acluser:")
+
+if [ -z "$ACL_LINE" ]; then
+    echo "FAIL: No ACL entry found for acluser"
+    exit 1
+fi
+
+echo "ACL entry: $ACL_LINE"
+
+# Check the entry has write permission (rwx or rw-)
+if echo "$ACL_LINE" | grep -q "user:acluser:rw"; then
+    echo "PASS: ACL write permission preserved for acluser"
+else
+    echo "FAIL: ACL write permission lost for acluser"
+    echo "Expected user:acluser:rw[x-] but got: $ACL_LINE"
+
+    # Also check effective permissions
+    EFFECTIVE=$(getfacl "$UPLOADED" 2>/dev/null | grep "^mask::")
+    echo "Mask entry: $EFFECTIVE"
+    exit 1
+fi
+
+# Also verify the mask allows write
+MASK_LINE=$(getfacl "$UPLOADED" 2>/dev/null | grep "^mask::")
+echo "Mask entry: $MASK_LINE"
+
+if echo "$MASK_LINE" | grep -q "mask::rw"; then
+    echo "PASS: ACL mask preserves write permission"
+else
+    echo "FAIL: ACL mask does not include write permission"
+    echo "Got: $MASK_LINE"
+    exit 1
+fi
+
+echo ""
+echo "=== All ACL tests passed ==="


### PR DESCRIPTION
## Summary

- Fixes #69 — POSIX ACL write bits (`rwX`) silently degraded to `#effective:r-x` when files were uploaded or modified via SFTP
- **Root cause**: `chmod()` in `DoSetStat()` and `open()` in `FSOpenFile()` automatically reset the ACL mask to match the file mode's group bits, making named ACL entries (e.g., `user:joe:rwx`) ineffective
- **Fix**: Added `FSRecalcAclMask()` which calls `acl_calc_mask()` + `acl_set_file()` to recompute the mask from actual ACL entries after `chmod()` and file creation

### Files changed

| File | Change |
|------|--------|
| `SftpServer/FileSystemAcl.c` | New `FSRecalcAclMask()` function (Linux + Cygwin stub) |
| `SftpServer/FileSystemAcl.h` | Declaration + no-op macro when ACL is disabled |
| `SftpServer/Sftp.c` | Call `FSRecalcAclMask()` after `chmod()` in `DoSetStat()` |
| `SftpServer/FileSystem.c` | Call `FSRecalcAclMask()` after `open()` with `O_CREAT` in `FSOpenFile()` |

## Test plan

- [x] Docker integration test added (`tests/docker-acl-test/`):
  - Sets up directory with default ACLs granting a secondary user `rwx`
  - Uploads a file via SFTP through MySecureShell
  - Verifies ACL entry retains write permission (no `#effective:r-x`)
  - Verifies ACL mask includes write bit

```bash
docker build -f tests/docker-acl-test/Dockerfile -t mss-acl-test .
docker run --rm mss-acl-test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)